### PR TITLE
Fix Broken Internal Links on Command Pages in Docs

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -48,7 +48,12 @@ func main() {
 
 		cmdOutput := new(bytes.Buffer)
 
-		err = doc.GenMarkdown(childCmd, cmdOutput)
+		linkHandler := func(cmdName string) string {
+			base := strings.TrimSuffix(cmdName, filepath.Ext(cmdName))
+			return strings.ToLower(base)
+		}
+
+		err = doc.GenMarkdownCustom(childCmd, cmdOutput, linkHandler)
 
 		if err != nil {
 			log.Fatal(err)

--- a/docs.go
+++ b/docs.go
@@ -24,11 +24,16 @@ func main() {
 		koolFile   *os.File
 	)
 
+	linkHandler := func(filename string) string {
+		base := strings.TrimSuffix(filename, filepath.Ext(filename))
+		return strings.ToLower(base)
+	}
+
 	fmt.Println("Going to generate cobra docs in markdown...")
 
 	koolOutput = new(bytes.Buffer)
 
-	err = doc.GenMarkdown(cmd.RootCmd(), koolOutput)
+	err = doc.GenMarkdownCustom(cmd.RootCmd(), koolOutput, linkHandler)
 
 	if err != nil {
 		log.Fatal(err)
@@ -47,11 +52,6 @@ func main() {
 		koolMarkdown = strings.Replace(koolMarkdown, cmdName, newName, -1)
 
 		cmdOutput := new(bytes.Buffer)
-
-		linkHandler := func(cmdName string) string {
-			base := strings.TrimSuffix(cmdName, filepath.Ext(cmdName))
-			return strings.ToLower(base)
-		}
 
 		err = doc.GenMarkdownCustom(childCmd, cmdOutput, linkHandler)
 

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -17,17 +17,17 @@ Complete documentation is available at https://kool.dev/docs
 
 ### SEE ALSO
 
-* [kool create](kool-create.md)	 - Create a new project using preset
-* [kool docker](kool-docker.md)	 - Creates a new container and runs the command in it.
-* [kool exec](kool-exec.md)	 - Execute a command within a running service container
-* [kool info](kool-info.md)	 - Prints out information about kool setup (like environment variables)
-* [kool logs](kool-logs.md)	 - Displays log output from services.
-* [kool preset](kool-preset.md)	 - Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
-* [kool restart](kool-restart.md)	 - Restart containers - the same as stop followed by start.
-* [kool run](kool-run.md)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
-* [kool self-update](kool-self-update.md)	 - Update kool to latest version
-* [kool share](kool-share.md)	 - Live share your local environment through an HTTP tunnel with anyone, anywhere.
-* [kool start](kool-start.md)	 - Start the specified Kool environment containers. If no service is specified, start all.
-* [kool status](kool-status.md)	 - Shows the status for containers
-* [kool stop](kool-stop.md)	 - Stop and destroy running containers started with 'kool start' command. If no SERVICE is specified as an argument all containers will be stopped.
+* [kool create](kool-create)	 - Create a new project using preset
+* [kool docker](kool-docker)	 - Creates a new container and runs the command in it.
+* [kool exec](kool-exec)	 - Execute a command within a running service container
+* [kool info](kool-info)	 - Prints out information about kool setup (like environment variables)
+* [kool logs](kool-logs)	 - Displays log output from services.
+* [kool preset](kool-preset)	 - Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
+* [kool restart](kool-restart)	 - Restart containers - the same as stop followed by start.
+* [kool run](kool-run)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
+* [kool self-update](kool-self-update)	 - Update kool to latest version
+* [kool share](kool-share)	 - Live share your local environment through an HTTP tunnel with anyone, anywhere.
+* [kool start](kool-start)	 - Start the specified Kool environment containers. If no service is specified, start all.
+* [kool status](kool-status)	 - Shows the status for containers
+* [kool stop](kool-stop)	 - Stop and destroy running containers started with 'kool start' command. If no SERVICE is specified as an argument all containers will be stopped.
 

--- a/docs/4-Commands/0-kool.md
+++ b/docs/4-Commands/0-kool.md
@@ -17,17 +17,17 @@ Complete documentation is available at https://kool.dev/docs
 
 ### SEE ALSO
 
-* [kool create](kool-create)	 - Create a new project using preset
-* [kool docker](kool-docker)	 - Creates a new container and runs the command in it.
-* [kool exec](kool-exec)	 - Execute a command within a running service container
-* [kool info](kool-info)	 - Prints out information about kool setup (like environment variables)
-* [kool logs](kool-logs)	 - Displays log output from services.
-* [kool preset](kool-preset)	 - Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
-* [kool restart](kool-restart)	 - Restart containers - the same as stop followed by start.
-* [kool run](kool-run)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
-* [kool self-update](kool-self-update)	 - Update kool to latest version
-* [kool share](kool-share)	 - Live share your local environment through an HTTP tunnel with anyone, anywhere.
-* [kool start](kool-start)	 - Start the specified Kool environment containers. If no service is specified, start all.
-* [kool status](kool-status)	 - Shows the status for containers
-* [kool stop](kool-stop)	 - Stop and destroy running containers started with 'kool start' command. If no SERVICE is specified as an argument all containers will be stopped.
+* [kool create](kool-create.md)	 - Create a new project using preset
+* [kool docker](kool-docker.md)	 - Creates a new container and runs the command in it.
+* [kool exec](kool-exec.md)	 - Execute a command within a running service container
+* [kool info](kool-info.md)	 - Prints out information about kool setup (like environment variables)
+* [kool logs](kool-logs.md)	 - Displays log output from services.
+* [kool preset](kool-preset.md)	 - Initialize kool preset in the current working directory. If no preset argument is specified you will be prompted to pick among the existing options.
+* [kool restart](kool-restart.md)	 - Restart containers - the same as stop followed by start.
+* [kool run](kool-run.md)	 - Runs a custom command defined at kool.yaml in the working directory or in the kool folder of the user's home directory
+* [kool self-update](kool-self-update.md)	 - Update kool to latest version
+* [kool share](kool-share.md)	 - Live share your local environment through an HTTP tunnel with anyone, anywhere.
+* [kool start](kool-start.md)	 - Start the specified Kool environment containers. If no service is specified, start all.
+* [kool status](kool-status.md)	 - Shows the status for containers
+* [kool stop](kool-stop.md)	 - Stop and destroy running containers started with 'kool start' command. If no SERVICE is specified as an argument all containers will be stopped.
 


### PR DESCRIPTION
I found the solution by reviewing https://github.com/spf13/cobra/blob/master/doc/md_docs.md, and discovering the `GenMarkdownCustom` method, and `linkHandler` callback.